### PR TITLE
fix(credentials):  work on error displaying some schemas

### DIFF
--- a/backend/src/modules/schema/schema.controller.ts
+++ b/backend/src/modules/schema/schema.controller.ts
@@ -15,8 +15,6 @@ import { SchemaModel } from '../../models/Schemas';
 import { UserService } from '../user/user.service';
 import VeridaHelper from 'src/helpers/VeridaHelper';
 import { UserIdentity } from 'src/models/User';
-// import Verida from '@verida/datastore';
-// import { SCHEMAS } from 'src/utils/schemas';
 
 @UseGuards(AuthGuard('jwt'))
 @Controller('schema')
@@ -25,7 +23,7 @@ export class SchemaController {
     private authService: AuthService,
     private schemaService: SchemaService,
     private userService: UserService,
-  ) {}
+  ) { }
 
   @UseGuards(AuthGuard('jwt'))
   @Get()
@@ -33,9 +31,11 @@ export class SchemaController {
     const user = (await this.authService.userByToken(headers)) as UserIdentity;
     const response = await this.schemaService.getSchemas(user['issuerId']);
 
+    const schemaTitles = response.map(res => res.schemaUrl)
+
     const schemas = await Promise.all(
-      response.map(schema =>
-        VeridaHelper.getSchemaJSon(user.issuer, schema.schemaUrl),
+      schemaTitles.map(schema =>
+        VeridaHelper.getSchemaJSon(user.issuer, schema),
       ),
     );
 

--- a/frontend/src/config/map.js
+++ b/frontend/src/config/map.js
@@ -1,47 +1,47 @@
 export const schemas = {
-  "https://common.schemas.verida.io/health/pathology/tests/cholesterol/total/v0.1.0/schema.json": {
-    view: ["testType", "testResult"],
-    create: [
-      "fullName",
-      "dateOfBirth",
-      "patientId",
-      "testTimestamp",
-      "result",
-      "acceptable",
-    ],
-  },
-  "https://27tqk.csb.app/schemas/health-prescription.json": {
-    view: ["name", "medication", "issueDate"],
-    create: ["name", "notes", "medication", "dateOfBirth", "purpose"],
-  },
-  "https://common.schemas.verida.io/health/pathology/tests/covid19/pcr/v0.1.0/schema.json": {
-    view: ["testType", "testResult"],
-    create: ["fullName", "dateOfBirth", "patientId", "testTimestamp", "result"],
-  },
-  "https://common.schemas.verida.io/health/pathology/tests/glucose/fasting/v0.1.0/schema.json": {
-    view: ["testType", "testResult"],
-    create: [
-      "fullName",
-      "dateOfBirth",
-      "patientId",
-      "testTimestamp",
-      "result",
-      "acceptable",
-    ],
-  },
-  "https://common.schemas.verida.io/health/pathology/tests/haemoglobin/v0.1.0/schema.json": {
-    view: ["testType", "testResult"],
-    create: [
-      "fullName",
-      "dateOfBirth",
-      "patientId",
-      "testTimestamp",
-      "result",
-      "acceptable",
-    ],
-  },
-  "https://common.schemas.verida.io/health/pathology/tests/syphilis/ab/v0.1.0/schema.json": {
-    view: ["testType", "testResult"],
-    create: ["fullName", "dateOfBirth", "patientId", "testTimestamp", "result"],
-  },
+	"https://common.schemas.verida.io/health/pathology/tests/cholesterol/total/v0.1.0/schema.json": {
+		view: ["testType", "testResult"],
+		create: [
+			"fullName",
+			"dateOfBirth",
+			"patientId",
+			"testTimestamp",
+			"result",
+			"acceptable",
+		],
+	},
+	// "https://27tqk.csb.app/schemas/health-prescription.json": {
+	//   view: ["name", "medication", "issueDate"],
+	//   create: ["name", "notes", "medication", "dateOfBirth", "purpose"],
+	// },
+	"https://common.schemas.verida.io/health/pathology/tests/covid19/pcr/v0.1.0/schema.json": {
+		view: ["testType", "testResult"],
+		create: ["fullName", "dateOfBirth", "patientId", "testTimestamp", "result"],
+	},
+	"https://common.schemas.verida.io/health/pathology/tests/glucose/fasting/v0.1.0/schema.json": {
+		view: ["testType", "testResult"],
+		create: [
+			"fullName",
+			"dateOfBirth",
+			"patientId",
+			"testTimestamp",
+			"result",
+			"acceptable",
+		],
+	},
+	"https://common.schemas.verida.io/health/pathology/tests/haemoglobin/v0.1.0/schema.json": {
+		view: ["testType", "testResult"],
+		create: [
+			"fullName",
+			"dateOfBirth",
+			"patientId",
+			"testTimestamp",
+			"result",
+			"acceptable",
+		],
+	},
+	"https://common.schemas.verida.io/health/pathology/tests/syphilis/ab/v0.1.0/schema.json": {
+		view: ["testType", "testResult"],
+		create: ["fullName", "dateOfBirth", "patientId", "testTimestamp", "result"],
+	},
 };


### PR DESCRIPTION
- [x] Modified credential list to view all schemas and send without crashing server

@nick-verida 

I have created a PR that fixes the issue, also noticed two schemas were not displaying as well, it throws a 403 error when trying to get their schema specification, I have tested this and it worked correctly



### screenshot of the error I got.
  
<img width="1058" alt="Screenshot 2022-06-01 at 09 35 39" src="https://user-images.githubusercontent.com/54280620/171363234-75f1e21e-f4a4-4b7c-9fd1-2544a1714d1a.png">

This happens for these two schemas 

```
  'https://common.schemas.verida.io/health/pathology/tests/haemoglobin/v0.1.0/schema.json'
  'https://common.schemas.verida.io/health/pathology/tests/syphilis/ab/v0.1.0/schema.json'

```



#78